### PR TITLE
Handle repeated serialization

### DIFF
--- a/lib/literal_enums/rails/enum_type.rb
+++ b/lib/literal_enums/rails/enum_type.rb
@@ -15,7 +15,8 @@ module LiteralEnums
       end
 
       def serialize(value)
-        value.value
+        return value.value if value.is_a?(@enum)
+        value
       end
     end
   end


### PR DESCRIPTION
This seems to be needed by ActiveRecord when an enum is used in an array value to `where`.

Fixes #1 